### PR TITLE
Improve performance of CF cli install

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Install CloudFoundry CLI
         run: |
-          brew install cloudfoundry/tap/cf-cli@7
+          curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v7&source=github" | sudo tar -zx --directory=/usr/local/bin
           cf --version
 
       - name: Setup CF CLI auth and target environment


### PR DESCRIPTION
The Homebrew CF cli install method takes anywhere from 30s to 1m, while
this binary install method should take less than 5s. We want to get to
the important part of the action we're doing as quickly as possible, so
not wasting time installing tools helps with that.