### PR TITLE
Update consumer info

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,10 @@ If you have a development instance running, you can add a new Kong Consumer and
 OAuth credentials by running:
 ```shell
 # This request will return an "id" that is needed for the next request.
-curl -X POST http://localhost:8081/consumers/ \
-    --data "username=<your-username>"
+curl -X POST http://localhost:8081/consumers/ --data "username=<your-username>" --data "custom_id=<your-custom-id>"
 
 # This request will return the client_id and client_secret to generate OAuth tokens with
-curl -X POST http://localhost:8081/consumers/<id-from-first-curl-response>/oauth2 \
-    --data "name=Global%20OAuth%20Application"
+curl -X POST http://localhost:8081/consumers/<id-from-first-curl-response>/oauth2 --data "name=Global%20OAuth%20Application"
 ```
 
 ### Generating tokens


### PR DESCRIPTION
Add data section for custom_id that is mandatory for consumer setup
within GIVE. Switched "curl" commands to be one line to facilitate
easier copy/pasting when creating new consumers.