### PR TITLE
Allow POST methods to generate oauth tokens

### DIFF
--- a/kong-dev.yaml
+++ b/kong-dev.yaml
@@ -32,6 +32,7 @@ services:
       - name: usps-route
         methods:
           - GET
+          - POST
         paths:
           - /usps
         path_handling: v0

--- a/kong-prod.yaml
+++ b/kong-prod.yaml
@@ -32,6 +32,7 @@ services:
       - name: usps-route
         methods:
           - GET
+          - POST
         paths:
           - /usps
         path_handling: v0

--- a/kong-test.yaml
+++ b/kong-test.yaml
@@ -32,6 +32,7 @@ services:
       - name: usps-route
         methods:
           - GET
+          - POST
         paths:
           - /usps
         path_handling: v0


### PR DESCRIPTION
Without allowing POST operations on the USPS service, users are not allowed
to generate oauth tokens with this endpoint.