### PR TITLE
remove ssl from proxy_listen config

### DIFF
--- a/kong.conf
+++ b/kong.conf
@@ -2,7 +2,7 @@
 headers = off
 database = off
 declarative_config = /home/vcap/app/kong.yaml
-proxy_listen = 0.0.0.0:8080 http2 ssl reuseport backlog=16384
+proxy_listen = 0.0.0.0:8080 http2 reuseport backlog=16384
 admin_listen = 127.0.0.1:8081 http2 ssl reuseport backlog=16384
 status_listen = 0.0.0.0:8100
 log_level = notice


### PR DESCRIPTION
ssl is terminated by cloud.gov load balancer so this proxy will not receive ssl traffic