### PR TITLE
Correct tsv format

### DIFF
--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,2 +1,1 @@
-# zap rule configuration file
-40025 IGNORE (Proxy Disclosure)
+40025	IGNORE	(Proxy Disclosure)


### PR DESCRIPTION
TSV files need to be tab-separated, not space separated. It's also
unclear how zap handles comments in tsv files so removing the
superfluous "rule configuration file" comment at the top of the file
should also help in getting the tool to correctly process this file.
