### PR TITLE
Scan all available urls for the API Gateway

### DIFF
--- a/.github/workflows/zap-scan.yaml
+++ b/.github/workflows/zap-scan.yaml
@@ -11,7 +11,7 @@ on:
     types: [completed]
 
 jobs:
-  zap_scan:
+  zap_scan_api:
     if: github.repository_owner == '18F'
     runs-on: ubuntu-latest
     name: Scan the API Gateway
@@ -21,5 +21,31 @@ jobs:
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.2.0
         with:
-          target: "https://idva-dev.app.cloud.gov"
+          target: "https://idva-api-dev.app.cloud.gov"
+          rules_file_name: ".zap/rules.tsv"
+
+  zap_scan_sdk:
+    if: github.repository_owner == '18F'
+    runs-on: ubuntu-latest
+    name: Scan the API Gateway
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: ZAP Scan
+        uses: zaproxy/action-full-scan@v0.2.0
+        with:
+          target: "https://idva-sdk-dev.app.cloud.gov"
+          rules_file_name: ".zap/rules.tsv"
+
+  zap_scan_portal:
+    if: github.repository_owner == '18F'
+    runs-on: ubuntu-latest
+    name: Scan the API Gateway
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: ZAP Scan
+        uses: zaproxy/action-full-scan@v0.2.0
+        with:
+          target: "https://idva-portal-dev.app.cloud.gov"
           rules_file_name: ".zap/rules.tsv"


### PR DESCRIPTION
We have removed the default `idva-dev` url. We should now be scanning all `app.cloud.gov` urls available via the API Gateway.